### PR TITLE
add alt attributes to skills logo to improve SEO and accessibility

### DIFF
--- a/app/src/Components/Skills.jsx
+++ b/app/src/Components/Skills.jsx
@@ -29,7 +29,7 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg'>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='react.png' width="50px" />
+                                    <img src='react.png' width="50px" alt="ReactJS" />
                                     <p className='text-white text-[20px]'>ReactJS</p>
                                 </div>
                             </div>
@@ -37,15 +37,15 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='nodejs.png' width="50px" />
-                                    <p className='text-white text-[20px]'>Node </p>
+                                    <img src='nodejs.png' width="50px" alt="Node.js"/>
+                                    <p className='text-white text-[20px]'>Node.js</p>
                                 </div>
                             </div>
                         </div>
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='javascript.png' width="50px" />
+                                    <img src='javascript.png' width="50px" alt="JavaScript"/>
                                     <p className='text-white text-[20px]'>JavaScript</p>
                                 </div>
                             </div>
@@ -53,7 +53,7 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='mongodb.png' width="50px" />
+                                    <img src='mongodb.png' width="50px" alt="MongoDB" />
                                     <p className='text-white text-[20px]'>MongoDB</p>
                                 </div>
                             </div>
@@ -61,15 +61,15 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='tailwindcss.png' width="50px" />
-                                    <p className='text-white text-[20px]'>Tailwind </p>
+                                    <img src='tailwindcss.png' width="50px" alt="Tailwind CSS" />
+                                    <p className='text-white text-[20px]'>Tailwind CSS</p>
                                 </div>
                             </div>
                         </div>
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='git.png' width="50px" />
+                                    <img src='git.png' width="50px" alt="git" />
                                     <p className='text-white text-[20px]'>Git</p>
                                 </div>
                             </div>
@@ -77,7 +77,7 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='bootstrap.png' width="50px" />
+                                    <img src='bootstrap.png' width="50px" alt="Bootstrap" />
                                     <p className='text-white text-[20px]'>Bootstrap</p>
                                 </div>
                             </div>
@@ -85,7 +85,7 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='figma.png' width="50px" />
+                                    <img src='figma.png' width="50px" alt="Figma" />
                                     <p className='text-white text-[20px]'>Figma</p>
                                 </div>
                             </div>
@@ -93,7 +93,7 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='github.png' width="50px" />
+                                    <img src='github.png' width="50px" alt="GitHub" />
                                     <p className='text-white text-[20px]'>Github</p>
                                 </div>
                             </div>
@@ -101,7 +101,7 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='redux.png' width="50px" />
+                                    <img src='redux.png' width="50px" alt="Redux" />
                                     <p className='text-white text-[20px]'>Redux</p>
                                 </div>
                             </div>
@@ -109,15 +109,15 @@ function Skills() {
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='mysql.png' width="50px" />
-                                    <p className='text-white text-[20px]'>My SQL</p>
+                                    <img src='mysql.png' width="50px" alt="MySQL" />
+                                    <p className='text-white text-[20px]'>MySQL</p>
                                 </div>
                             </div>
                         </div>
                         <div className=' flex items-center flex-col justify-center p-4'>
                             <div className='bg-neutral-950 p-4 w-[200px] rounded-lg '>
                                 <div className='flex items-center justify-center gap-4  '>
-                                    <img src='reactnative.png' width="50px" />
+                                    <img src='reactnative.png' width="50px" alt="React Native" />
                                     <p className='text-white text-[20px]'>React Native</p>
                                 </div>
                             </div>


### PR DESCRIPTION
`img` tags should include `alt` attributes to improve accessibility for users that rely on screen readers and for all users when images fail to load.

I also update the names of Node.js and Tailwind CSS according to their branding pages. https://tailwindcss.com/brand https://nodejs.org/en/about/branding